### PR TITLE
Horrifying workaround

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id "architectury-plugin" version "2.0.65"
-	id "forgified-fabric-loom" version "0.6.56" apply false
+	id "architectury-plugin" version "3.0-SNAPSHOT"
+	id "forgified-fabric-loom" version "0.6-SNAPSHOT" apply false
 	id "com.matthewprenger.cursegradle" version "1.4.0" apply false
 	id "maven-publish"
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,14 +2,14 @@ dependencies {
 	minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
 	mappings minecraft.officialMojangMappings()
 
-	modCompile "me.shedaniel:architectury:${rootProject.architectury_version}"
+	modApi "me.shedaniel:architectury-snapshot:${rootProject.architectury_version}"
 	compileOnly "com.google.code.findbugs:jsr305:3.+"
 	// We depend on fabric loader here to use the fabric @Environment annotations
 	// Do NOT use other classes from fabric loader
-	modCompile "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+	modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
 
 	// FIXME: DO NOT USE ANY FABRIC CLASSES FROM THIS...lat pls
-	modCompile("curse.maven:kubejs-fabric-395864:${rootProject.fabric_kjs_file}")
+	modApi("curse.maven:kubejs-fabric-395864:${rootProject.fabric_kjs_file}")
 }
 
 def ENV = System.getenv()

--- a/common/src/main/java/dev/latvian/kubejs/ui/KubeJSUI.java
+++ b/common/src/main/java/dev/latvian/kubejs/ui/KubeJSUI.java
@@ -1,10 +1,15 @@
 package dev.latvian.kubejs.ui;
 
 import me.shedaniel.architectury.event.events.GuiEvent;
+import me.shedaniel.architectury.platform.Platform;
 import me.shedaniel.architectury.registry.ReloadListeners;
 import me.shedaniel.architectury.utils.Env;
 import me.shedaniel.architectury.utils.EnvExecutor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
 
 /**
  * @author LatvianModder
@@ -12,6 +17,7 @@ import net.minecraft.server.packs.PackType;
 public class KubeJSUI
 {
 	public static final String MOD_ID = "kubejs_ui";
+	static ThreadLocal<Boolean> withinInitPreHacks = ThreadLocal.withInitial(() -> false);
 
 	private KubeJSUI()
 	{
@@ -21,6 +27,32 @@ public class KubeJSUI
 	{
 		EnvExecutor.runInEnv(Env.CLIENT, () -> () -> {
 			GuiEvent.SET_SCREEN.register(KubeJSUIEventHandler::openGui);
+			if (!Platform.isForge())
+			{
+				GuiEvent.INIT_PRE.register((screen, widgets, children) -> {
+					if (withinInitPreHacks.get()) return InteractionResult.PASS;
+					if (Minecraft.getInstance().screen != screen) return InteractionResult.PASS;
+					if (screen instanceof ScreenKubeJSUI) return InteractionResult.PASS;
+
+					String screenId = UIData.INSTANCE.getScreenId(screen.getClass());
+
+					if (!screenId.isEmpty())
+					{
+						// Re-open the screen
+						withinInitPreHacks.set(true);
+						try
+						{
+							Minecraft.getInstance().setScreen(screen);
+						} finally
+						{
+							withinInitPreHacks.set(false);
+						}
+						return InteractionResult.SUCCESS;
+					}
+
+					return InteractionResult.PASS;
+				});
+			}
 			ReloadListeners.registerReloadListener(PackType.CLIENT_RESOURCES, UIData.INSTANCE);
 		});
 	}

--- a/common/src/main/java/dev/latvian/kubejs/ui/UIData.java
+++ b/common/src/main/java/dev/latvian/kubejs/ui/UIData.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.latvian.kubejs.KubeJS;
 import dev.latvian.kubejs.util.UtilsJS;
+import me.shedaniel.architectury.platform.Platform;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
@@ -73,10 +75,13 @@ public enum UIData implements ResourceManagerReloadListener
 						{
 							for (Map.Entry<String, JsonElement> entry : json.get("screens").getAsJsonObject().entrySet())
 							{
+								if (Platform.isFabric())
+								{
+									addMappedScreen(entry);
+								}
 								try
 								{
-									Class<?> clazz = Class.forName(entry.getKey());
-									screenIds.put(clazz, entry.getValue().getAsString());
+									screenIds.put(Class.forName(entry.getKey()), entry.getValue().getAsString());
 								}
 								catch (Throwable ex)
 								{
@@ -90,6 +95,20 @@ public enum UIData implements ResourceManagerReloadListener
 			catch (Exception ignored)
 			{
 			}
+		}
+	}
+
+	private void addMappedScreen(Map.Entry<String, JsonElement> entry)
+	{
+		if (FabricLoader.getInstance().getMappingResolver().getCurrentRuntimeNamespace().equals("intermediary")) return;
+		try
+		{
+			String className = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", entry.getKey());
+			screenIds.put(Class.forName(className), entry.getValue().getAsString());
+		}
+		catch (Throwable ex)
+		{
+			// KubeJS.LOGGER.error("UI: Failed to load screen " + entry.getKey() + ":" + entry.getValue() + ": " + ex);
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/kubejs/ui/UIData.java
+++ b/common/src/main/java/dev/latvian/kubejs/ui/UIData.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.latvian.kubejs.KubeJS;
 import dev.latvian.kubejs.util.UtilsJS;
+import me.shedaniel.architectury.annotations.ExpectPlatform;
 import me.shedaniel.architectury.platform.Platform;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screens.Screen;
@@ -77,7 +78,7 @@ public enum UIData implements ResourceManagerReloadListener
 							{
 								if (Platform.isFabric())
 								{
-									addMappedScreen(entry);
+									addMappedScreen(screenIds, entry);
 								}
 								try
 								{
@@ -98,18 +99,10 @@ public enum UIData implements ResourceManagerReloadListener
 		}
 	}
 
-	private void addMappedScreen(Map.Entry<String, JsonElement> entry)
+	@ExpectPlatform
+	private static void addMappedScreen(Map<Class<?>, String> screenIds, Map.Entry<String, JsonElement> entry)
 	{
-		if (FabricLoader.getInstance().getMappingResolver().getCurrentRuntimeNamespace().equals("intermediary")) return;
-		try
-		{
-			String className = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", entry.getKey());
-			screenIds.put(Class.forName(className), entry.getValue().getAsString());
-		}
-		catch (Throwable ex)
-		{
-			// KubeJS.LOGGER.error("UI: Failed to load screen " + entry.getKey() + ":" + entry.getValue() + ": " + ex);
-		}
+		throw new AssertionError();
 	}
 
 	private final Map<Class<?>, String> screenIds = new HashMap<>();

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -6,11 +6,12 @@ plugins {
 def ENV = System.getenv()
 
 configurations {
-	shadow
+	shadowCommon
 }
 
 architectury {
 	platformSetupLoomIde()
+	fabric()
 }
 
 repositories {
@@ -22,25 +23,25 @@ repositories {
 dependencies {
 	minecraft("com.mojang:minecraft:${rootProject.minecraft_version}")
 	mappings(minecraft.officialMojangMappings())
-	modCompile("net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}")
-	modCompile("net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}")
+	modImplementation("net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}")
+	modApi("net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}")
 
-	modCompile("me.shedaniel:architectury:${rootProject.architectury_version}:fabric")
+	modApi("me.shedaniel:architectury-snapshot-fabric:${rootProject.architectury_version}")
 
-	compileOnly(project(path: ":common")) {
+	implementation(project(path: ":common")) {
 		transitive = false
 	}
-	runtimeOnly(project(path: ":common", configuration: "transformDevelopmentFabric")) {
+	developmentFabric(project(path: ":common")) {
 		transitive = false
 	}
-	shadow(project(path: ":common", configuration: "transformProductionFabric")) {
+	shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) {
 		transitive = false
 	}
 
-	modCompile("curse.maven:kubejs-fabric-395864:${rootProject.fabric_kjs_file}")
-	modCompile("curse.maven:rhino-416294:${rootProject.rhino_file}")
+	modApi("curse.maven:kubejs-fabric-395864:${rootProject.fabric_kjs_file}")
+	modApi("curse.maven:rhino-416294:${rootProject.rhino_file}")
 
-    modCompile("com.terraformersmc:modmenu:${rootProject.fabric_mod_menu_version}")
+	modApi("com.terraformersmc:modmenu:${rootProject.fabric_mod_menu_version}")
 
 	modCompileOnly("me.shedaniel:RoughlyEnoughItems-api:${rootProject.fabric_rei_version}") {
 		exclude group: "net.fabricmc.fabric-api"
@@ -61,7 +62,7 @@ processResources {
 }
 
 shadowJar {
-	configurations = [project.configurations.shadow]
+	configurations = [project.configurations.shadowCommon]
 	classifier "shadow"
 }
 

--- a/fabric/src/main/java/dev/latvian/kubejs/ui/fabric/UIDataImpl.java
+++ b/fabric/src/main/java/dev/latvian/kubejs/ui/fabric/UIDataImpl.java
@@ -1,0 +1,23 @@
+package dev.latvian.kubejs.ui.fabric;
+
+import com.google.gson.JsonElement;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.Map;
+
+public class UIDataImpl
+{
+	public static void addMappedScreen(Map<Class<?>, String> screenIds, Map.Entry<String, JsonElement> entry)
+	{
+		if (FabricLoader.getInstance().getMappingResolver().getCurrentRuntimeNamespace().equals("intermediary")) return;
+		try
+		{
+			String className = FabricLoader.getInstance().getMappingResolver().mapClassName("intermediary", entry.getKey());
+			screenIds.put(Class.forName(className), entry.getValue().getAsString());
+		}
+		catch (Throwable ex)
+		{
+			// KubeJS.LOGGER.error("UI: Failed to load screen " + entry.getKey() + ":" + entry.getValue() + ": " + ex);
+		}
+	}
+}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -6,15 +6,12 @@ plugins {
 def ENV = System.getenv()
 
 configurations {
-	shadow
+	shadowCommon
 }
 
 architectury {
 	platformSetupLoomIde()
-}
-
-loom {
-	useFabricMixin = true
+	forge()
 }
 
 dependencies {
@@ -22,22 +19,22 @@ dependencies {
 	mappings(minecraft.officialMojangMappings())
 	forge("net.minecraftforge:forge:${rootProject.minecraft_version}-${rootProject.forge_version}")
 
-	modCompile("me.shedaniel:architectury:${rootProject.architectury_version}:forge")
+	modApi("me.shedaniel:architectury-snapshot-forge:${rootProject.architectury_version}")
 
-	compileOnly(project(path: ":common")) {
+	implementation(project(path: ":common")) {
 		transitive = false
 	}
-	runtimeOnly(project(path: ":common", configuration: "transformDevelopmentForge")) {
+	developmentForge(project(path: ":common")) {
 		transitive = false
 	}
-	shadow(project(path: ":common", configuration: "transformProductionForge")) {
+	shadowCommon(project(path: ":common", configuration: "transformProductionForge")) {
 		transitive = false
 	}
 
-	modCompile("curse.maven:kubejs-238086:${rootProject.forge_kjs_file}")
-	modCompile("curse.maven:rhino-416294:${rootProject.rhino_file}")
+	modApi("curse.maven:kubejs-238086:${rootProject.forge_kjs_file}")
+	modApi("curse.maven:rhino-416294:${rootProject.rhino_file}")
 
-	modCompile("curse.maven:jei-238222:${rootProject.forge_jei_file}")
+	modApi("curse.maven:jei-238222:${rootProject.forge_jei_file}")
 }
 
 processResources {
@@ -51,7 +48,7 @@ processResources {
 shadowJar {
 	exclude "fabric.mod.json"
 
-	configurations = [project.configurations.shadow]
+	configurations = [project.configurations.shadowCommon]
 	classifier "shadow"
 }
 
@@ -68,7 +65,7 @@ jar {
 				"Specification-Vendor"    : project.mod_author,
 				"Specification-Version"   : "1",
 				"Implementation-Title"    : project.name,
-				"Implementation-Version"  : version,
+				"Implementation-Version"  : project.version,
 				"Implementation-Vendor"   : project.mod_author,
 				"Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
 		])

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,17 +6,17 @@ archives_base_name=kubejs-ui
 mod_version=1605.1.1
 maven_group=dev.latvian.mods
 mod_author=LatvianModder
-architectury_version=1.5.101
+architectury_version=1.8-PR.62.24
 curseforge_id_forge=423490
 curseforge_id_fabric=440283
 rhino_file=3187177
 # fabric
-fabric_loader_version=0.11.1
-fabric_api_version=0.30.0+1.16
+fabric_loader_version=0.11.3
+fabric_api_version=0.32.0+1.16
 fabric_kjs_file=3202130
 fabric_rei_version=5.8.3
 fabric_mod_menu_version=1.16.+
 # forge
-forge_version=36.0.14
+forge_version=36.0.58
 forge_kjs_file=3202129
 forge_jei_file=3136600

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
 	repositories {
 		jcenter()
 		maven { url "https://maven.fabricmc.net/" }
-		maven { url "https://dl.bintray.com/shedaniel/cloth" }
+		maven { url "https://maven.shedaniel.me/" }
 		maven { url "https://files.minecraftforge.net/maven/" }
 		gradlePluginPortal()
 	}


### PR DESCRIPTION
Starting from architectury 1.9, the mixin that moves the TitleScreen init to behave like forge is removed (See architectury/architectury-api#62), that PR breaks VoxelMap for the assumption for screen to never be null unless in a world.

This PR is updates arch to 3 and adds concerning workarounds to fix this issue once arch API 1.9 is released.